### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint: lint-flake lint-pep8
 	@echo "Done checking"
 
 test:
-	py.test --verbose --color=yes --cov=$(SOURCE) $(TESTS)
+	pytest --verbose --color=yes --cov=$(SOURCE) $(TESTS)
 	if [ -a picturfy-img.png ] ; then rm picturfy-img.png ; fi;
 	if [ -a assets/picturfy-img.png ] ; then rm assets/picturfy-img.png ; fi
 	

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-PYTHONPATH=. py.test
+PYTHONPATH=. pytest


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot